### PR TITLE
Potential fix for code scanning alert no. 19: Incomplete string escaping or encoding

### DIFF
--- a/api/services/rule-engine.service.ts
+++ b/api/services/rule-engine.service.ts
@@ -619,7 +619,9 @@ export class RuleEngineService {
 
         return excludePatterns.some((pattern: string) => {
             // Convert glob pattern to regex
+            // Escape backslashes
             const regexPattern = pattern
+                .replace(/\\/g, "\\\\")       // escape backslashes
                 .replace(/\./g, "\\.")
                 .replace(/\*/g, ".*")
                 .replace(/\?/g, ".");


### PR DESCRIPTION
Potential fix for [https://github.com/devasignhq/devasign-api/security/code-scanning/19](https://github.com/devasignhq/devasign-api/security/code-scanning/19)

The best way to address this issue is to use a well-tested library function to convert glob patterns to regular expressions, rather than manually replacing characters. If that is not feasible in this code region, we should at least ensure that backslash (`\`) characters are safely escaped in addition to the other meta-characters. This can be done by replacing all instances of a single backslash with a double backslash using `.replace(/\\/g, "\\\\")` before other replacements. Alternatively, we could apply escaping via lodash's `escapeRegExp` to the entire pattern before replacing glob-specific wildcards (`*`, `?`). The recommended fix within the shown code region is to add a replacement of backslashes on line 623, before calling `lodash.escapeRegExp`. The change should be limited to the function in question, with no further architectural changes needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
